### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
-PID         KEYWORD1
+PID	KEYWORD1
 
-setpoint    KEYWORD2
-setSetpoint KEYWORD2
-step        KEYWORD2
+setpoint	KEYWORD2
+setSetpoint	KEYWORD2
+step	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords